### PR TITLE
bugfix: ILogger<> dependency missing without explicitly add logging

### DIFF
--- a/src/JKang.IpcServiceFramework.Server/IpcServiceServiceCollectionExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ namespace JKang.IpcServiceFramework
         public static IIpcServiceBuilder AddIpc(this IServiceCollection services)
         {
             services
+                .AddLogging()
                 .AddScoped<IValueConverter, DefaultValueConverter>()
                 .AddScoped<IIpcMessageSerializer, DefaultIpcMessageSerializer>();
 

--- a/src/JKang.IpcServiceFramework.Server/JKang.IpcServiceFramework.Server.csproj
+++ b/src/JKang.IpcServiceFramework.Server/JKang.IpcServiceFramework.Server.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#37 