### PR TITLE
Added exception propagation to client in case of any error in ProcessAsync method, e.g. JSON serialization error

### DIFF
--- a/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
@@ -71,6 +71,7 @@ namespace JKang.IpcServiceFramework
                 catch (Exception ex)
                 {
                     logger?.LogError(ex, ex.Message);
+                    await writer.WriteAsync(IpcResponse.Fail($"Internal server error: {ex.Message}"), cancellationToken);
                 }
             }
         }


### PR DESCRIPTION
On my opinion, seeing server exception is better than a NullReferenceException thrown in a client.