### PR TITLE
Added Async methods implementation for contracts

### DIFF
--- a/src/IpcServiceSample.ConsoleClient/Program.cs
+++ b/src/IpcServiceSample.ConsoleClient/Program.cs
@@ -88,6 +88,14 @@ namespace IpcServiceSample.ConsoleClient
             // test 9: call slow IPC service method 
             await systemClient.InvokeAsync(x => x.SlowOperation(), cancellationToken);
             Console.WriteLine($"[TEST 9] Called slow operation");
+
+            // test 10: call async server method
+            await computingClient.InvokeAsync(x => x.MethodAsync());
+            Console.WriteLine($"[TEST 10] Called async method");
+
+            // test 11: call async server function
+            int sum = await computingClient.InvokeAsync(x => x.SumAsync(1, 1));
+            Console.WriteLine($"[TEST 11] Called async function: {sum}");
         }
     }
 }

--- a/src/IpcServiceSample.ConsoleServer/ComputingService.cs
+++ b/src/IpcServiceSample.ConsoleServer/ComputingService.cs
@@ -1,6 +1,7 @@
 ﻿using IpcServiceSample.ServiceContracts;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace IpcServiceSample.ConsoleServer
 {
@@ -34,6 +35,16 @@ namespace IpcServiceSample.ConsoleServer
         {
             _logger.LogInformation($"{nameof(AddFloat)} called.");
             return x + y;
+        }
+
+        public Task MethodAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task<int> SumAsync(int x, int y)
+        {
+            return Task.FromResult(x + y);
         }
     }
 }

--- a/src/IpcServiceSample.ServiceContracts/IComputingService.cs
+++ b/src/IpcServiceSample.ServiceContracts/IComputingService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace IpcServiceSample.ServiceContracts
 {
@@ -8,6 +9,9 @@ namespace IpcServiceSample.ServiceContracts
         float AddFloat(float x, float y);
         ComplexNumber AddComplexNumber(ComplexNumber x, ComplexNumber y);
         ComplexNumber AddComplexNumbers(IEnumerable<ComplexNumber> numbers);
+
+        Task MethodAsync();
+        Task<int> SumAsync(int x, int y);
     }
 
     public class ComplexNumber


### PR DESCRIPTION
I've added support for async methods in server contracts. 
With this change one can declare a contract like:

`
interface MyContract
{
   Task DoSomethingAsync();
   Task<int> SumAsync(int x, int y);
}
`

that is callable from client with usual code:

`
await computingClient.InvokeAsync(x => x.DoSomethingAsync());
int sum = await computingClient.InvokeAsync(x => x.SumAsync(1, 1));
`
