### PR TITLE
Fixed null value handling in method parameter values

### DIFF
--- a/src/JKang.IpcServiceFramework.Core/Services/DefaultValueConverter.cs
+++ b/src/JKang.IpcServiceFramework.Core/Services/DefaultValueConverter.cs
@@ -8,6 +8,12 @@ namespace JKang.IpcServiceFramework.Services
     {
         public bool TryConvert(object origValue, Type destType, out object destValue)
         {
+            if (origValue == null)
+            {
+                destValue = null;
+                return destType.IsClass || (Nullable.GetUnderlyingType(destType) != null);
+            }
+
             if (destType.IsAssignableFrom(origValue.GetType()))
             {
                 // copy value directly if it can be assigned to destType


### PR DESCRIPTION
I converted a project using WCF to target .NET Standard, which meant I needed a new framework. I did a straightforward translation to IpcServiceFramework, and pretty much the very first call produced `Internal server error: Object reference not set to an instance of an object`. I ran IpcServiceFramework from code, and the cause seems to be simple: The `TryConvert` method in `DefaultValueConverter` is written in such a way that assumes that no method parameter will _ever_ be `null` (specifically, it assumes it will always be able to call `origValue.GetType()`.

This PR adds code to the top of `TryConvert` to handle the case where `origValue` is `null`. In this case, the converted value will always be `null`, and the only question is whether it is a valid conversion, which it determines by checking that the destination type is either a class type or a `Nullable<T>` structure.

With this change, IpcServiceFramework works perfectly in my project. :-)