### PR TITLE
Added  AddService<TInterface> overload to IIpcServiceBuilder interface

### DIFF
--- a/src/JKang.IpcServiceFramework.Server/IIpcServiceBuilder.cs
+++ b/src/JKang.IpcServiceFramework.Server/IIpcServiceBuilder.cs
@@ -14,5 +14,8 @@ namespace JKang.IpcServiceFramework
         IIpcServiceBuilder AddService<TInterface, TImplementation>(Func<IServiceProvider, TImplementation> implementationFactory)
             where TInterface : class
             where TImplementation : class, TInterface;
+
+        IIpcServiceBuilder AddService<TInterface>(Func<IServiceProvider, TInterface> implementationFactory)
+            where TInterface : class;
     }
 }

--- a/src/JKang.IpcServiceFramework.Server/IpcServiceBuilder.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceBuilder.cs
@@ -27,5 +27,12 @@ namespace JKang.IpcServiceFramework
             Services.AddScoped<TInterface, TImplementation>(implementationFactory);
             return this;
         }
+
+        public IIpcServiceBuilder AddService<TInterface>(Func<IServiceProvider, TInterface> implementationFactory)
+            where TInterface : class
+        {
+            Services.AddScoped(implementationFactory);
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Sometimes you don't know the implementation type at design time so I've added an additional method to IIpcServiceBuilder that just map to internal `IServiceCollection.AddScoped<TInterface>(Func<IServiceProvider, TInterface> implementationFactory)`