### PR TITLE
Add support for overlapped TCP calls

### DIFF
--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpConcurrencyOptions.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpConcurrencyOptions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace JKang.IpcServiceFramework.Tcp
+{
+    public class TcpConcurrencyOptions
+    {
+        public int MaximumConcurrentCalls;
+
+        public TcpConcurrencyOptions(int maximumConcurrentCalls)
+        {
+            this.MaximumConcurrentCalls = maximumConcurrentCalls;
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
@@ -23,54 +23,65 @@ namespace JKang.IpcServiceFramework.Tcp
         private readonly TcpListener _listener;
         private readonly Func<Stream, Stream> _streamTranslator;
         private readonly X509Certificate _serverCertificate;
+        private readonly int _maximumConcurrentCalls;
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, TcpConcurrencyOptions concurrencyOptions)
             : base(name, serviceProvider)
         {
+            if (concurrencyOptions == null)
+                _maximumConcurrentCalls = 1;
+            else
+            {
+                _maximumConcurrentCalls = concurrencyOptions.MaximumConcurrentCalls;
+
+                if (_maximumConcurrentCalls < 1)
+                    _maximumConcurrentCalls = 1;
+            }
+
             _listener = new TcpListener(ipEndpoint, port);
             _logger = serviceProvider.GetService<ILogger<TcpIpcServiceEndpoint<TContract>>>();
             Port = port;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint)
-            : this(name, serviceProvider, ipEndpoint, 0)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions)
         {
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator)
-            : this(name, serviceProvider, ipEndpoint, 0)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions)
         {
             _streamTranslator = streamTranslator;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate)
-            : this(name, serviceProvider, ipEndpoint, 0)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions)
         {
             _serverCertificate = sslCertificate;
             SSL = true;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator)
-            : this(name, serviceProvider, ipEndpoint, sslCertificate)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, sslCertificate, concurrencyOptions)
         {
             _streamTranslator = streamTranslator;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator)
-            : this(name, serviceProvider, ipEndpoint, port)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, port, concurrencyOptions)
         {
             _streamTranslator = streamTranslator;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate)
-            : this(name, serviceProvider, ipEndpoint, port)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, port, concurrencyOptions)
         {
             _serverCertificate = sslCertificate;
             SSL = true;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator)
-            : this(name, serviceProvider, ipEndpoint, port, sslCertificate)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            : this(name, serviceProvider, ipEndpoint, port, sslCertificate, concurrencyOptions)
         {
             _streamTranslator = streamTranslator;
         }
@@ -91,9 +102,18 @@ namespace JKang.IpcServiceFramework.Tcp
             {
                 try
                 {
+                    SemaphoreSlim _throttle = null;
+
+                    if (_maximumConcurrentCalls > 1)
+                        _throttle = new SemaphoreSlim(_maximumConcurrentCalls);
+
                     _logger.LogDebug($"Endpoint '{Name}' listening on port {Port}...");
+
                     while (true)
                     {
+                        if (_throttle != null)
+                            await _throttle.WaitAsync();
+
                         TcpClient client = await _listener.AcceptTcpClientAsync();
 
                         Stream server = client.GetStream();
@@ -112,7 +132,26 @@ namespace JKang.IpcServiceFramework.Tcp
                             server = ssl;
                         }
 
-                        await ProcessAsync(server, _logger, cancellationToken);
+                        if (_throttle == null)
+                        {
+                            await ProcessAsync(server, _logger, cancellationToken);
+                        }
+                        else
+                        {
+                            var processTask = Task.Run(
+                                async () =>
+                                {
+                                    try
+                                    {
+                                        await ProcessAsync(server, _logger, cancellationToken);
+                                    }
+                                    catch when (cancellationToken.IsCancellationRequested) { }
+                                    finally
+                                    {
+                                        _throttle.Release();
+                                    }
+                                });
+                        }
                     }
                 }
                 catch when (cancellationToken.IsCancellationRequested)

--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceHostBuilderExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceHostBuilderExtensions.cs
@@ -12,56 +12,112 @@ namespace JKang.IpcServiceFramework
             string name, IPAddress ipEndpoint)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, int port)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, int port, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, streamTranslator));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, streamTranslator, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, streamTranslator, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, X509Certificate sslCertificate)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, sslCertificate, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, streamTranslator));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, sslCertificate, streamTranslator, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, streamTranslator, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, sslCertificate, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, streamTranslator));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, streamTranslator, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, streamTranslator, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, streamTranslator));
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, sslCertificate, streamTranslator, concurrencyOptions: null);
+        }
+
+        public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, streamTranslator, concurrencyOptions));
         }
     }
 }


### PR DESCRIPTION
The Named Pipes provider spools up multiple threads (the exact number configurable) which permits that many concurrent calls. But, the TCP provider uses a single thread in a loop accepting connections and then waiting until they are finished processing. As such, with the TCP provider, if a second call arrives while the first is still being processed, it must simply wait because there isn't any code accepting new connections until the first is finished.

This PR adds a configuration option to the `TcpIpcServiceEndpoint` class called `concurrencyOptions`, which has a field within it called `MaximumConcurrentCalls`. `TcpIpcServiceEndpoint` latches onto this value, and when it is greater than 1, the main TCP connection loop dispatches the processing of requests onto separate `Task`s, allowing the loop to immediately accept the next connection before the request has finished processing. A `SemaphoreSlim` is used to prevent it from accepting a new connection when it already has the maximum number of ongoing calls. `SemaphoreSlim` is a good fit because it has `async` methods that allow the `Task` thread to be released while it is blocked.

I need this because my service has a polling call that waits indefinitely, and I need to be able to make out-of-band calls to the same server while the polling is outstanding.

These changes seem to be working with my test project.

I've maintained backward-compatibility with the fluid builder extensions. I'm not sure if the `TcpIpcServiceEndpoint` constructor overloads also need to be kept compatible, if so then this'll need one more commit to add proxy overloads without the new `concurrencyOptions` parameter.