### PR TITLE
Added configureAwait(false) to the projects await calls to stop async…

### DIFF
--- a/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
@@ -28,7 +28,7 @@ namespace JKang.IpcServiceFramework
             CancellationToken cancellationToken = default(CancellationToken))
         {
             IpcRequest request = GetRequest(exp, new MyInterceptor());
-            IpcResponse response = await GetResponseAsync(request, cancellationToken);
+            IpcResponse response = await GetResponseAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.Succeed)
             {
@@ -44,7 +44,7 @@ namespace JKang.IpcServiceFramework
             CancellationToken cancellationToken = default(CancellationToken))
         {
             IpcRequest request = GetRequest(exp, new MyInterceptor<TResult>());
-            IpcResponse response = await GetResponseAsync(request, cancellationToken);
+            IpcResponse response = await GetResponseAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.Succeed)
             {
@@ -67,7 +67,7 @@ namespace JKang.IpcServiceFramework
             CancellationToken cancellationToken = default(CancellationToken))
         {
             IpcRequest request = GetRequest(exp, new MyInterceptor<Task>());
-            IpcResponse response = await GetResponseAsync(request, cancellationToken);
+            IpcResponse response = await GetResponseAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.Succeed)
             {
@@ -83,7 +83,7 @@ namespace JKang.IpcServiceFramework
             CancellationToken cancellationToken = default(CancellationToken))
         {
             IpcRequest request = GetRequest(exp, new MyInterceptor<Task<TResult>>());
-            IpcResponse response = await GetResponseAsync(request, cancellationToken);
+            IpcResponse response = await GetResponseAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (response.Succeed)
             {
@@ -131,7 +131,7 @@ namespace JKang.IpcServiceFramework
 
         private async Task<IpcResponse> GetResponseAsync(IpcRequest request, CancellationToken cancellationToken)
         {
-            using (Stream client = await ConnectToServerAsync(cancellationToken))
+            using (Stream client = await ConnectToServerAsync(cancellationToken).ConfigureAwait(false))
             using (var writer = new IpcWriter(client, _serializer, leaveOpen: true))
             using (var reader = new IpcReader(client, _serializer, leaveOpen: true))
             {

--- a/src/JKang.IpcServiceFramework.Client/NamedPipe/NamedPipeIpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/NamedPipe/NamedPipeIpcServiceClient.cs
@@ -1,4 +1,5 @@
 ﻿using JKang.IpcServiceFramework.Services;
+using System;
 using System.IO;
 using System.IO.Pipes;
 using System.Threading;
@@ -19,8 +20,8 @@ namespace JKang.IpcServiceFramework.NamedPipe
 
         protected override async Task<Stream> ConnectToServerAsync(CancellationToken cancellationToken)
         {
-            var stream = new NamedPipeClientStream(".", _pipeName, PipeDirection.InOut, PipeOptions.None);
-            await stream.ConnectAsync(cancellationToken);
+            var stream = new NamedPipeClientStream(".", _pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
+            await stream.ConnectAsync((int)TimeSpan.FromSeconds(3).TotalMilliseconds, cancellationToken).ConfigureAwait(false);
             return stream;
         }
     }

--- a/src/JKang.IpcServiceFramework.Client/Tcp/TcpIpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/Tcp/TcpIpcServiceClient.cs
@@ -78,7 +78,7 @@ namespace JKang.IpcServiceFramework.Tcp
                         cancellationToken.ThrowIfCancellationRequested();
                     }
                 }
-            });
+            }).ConfigureAwait(false);
 
             cancellationToken.Register(() =>
             {

--- a/src/JKang.IpcServiceFramework.Core/IO/IpcReader.cs
+++ b/src/JKang.IpcServiceFramework.Core/IO/IpcReader.cs
@@ -25,23 +25,23 @@ namespace JKang.IpcServiceFramework.IO
 
         public async Task<IpcRequest> ReadIpcRequestAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            byte[] binary = await ReadMessageAsync(cancellationToken);
+            byte[] binary = await ReadMessageAsync(cancellationToken).ConfigureAwait(false);
             return _serializer.DeserializeRequest(binary);
         }
 
         public async Task<IpcResponse> ReadIpcResponseAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            byte[] binary = await ReadMessageAsync(cancellationToken);
+            byte[] binary = await ReadMessageAsync(cancellationToken).ConfigureAwait(false);
             return _serializer.DeserializeResponse(binary);
         }
 
         private async Task<byte[]> ReadMessageAsync(CancellationToken cancellationToken)
         {
-            await _stream.ReadAsync(_lengthBuffer, 0, _lengthBuffer.Length, cancellationToken);
+            await _stream.ReadAsync(_lengthBuffer, 0, _lengthBuffer.Length, cancellationToken).ConfigureAwait(false);
             int length = _lengthBuffer[0] | _lengthBuffer[1] << 8 | _lengthBuffer[2] << 16 | _lengthBuffer[3] << 24;
 
             byte[] bytes = new byte[length];
-            await _stream.ReadAsync(bytes, 0, length, cancellationToken);
+            await _stream.ReadAsync(bytes, 0, length, cancellationToken).ConfigureAwait(false);
 
             return bytes;
         }

--- a/src/JKang.IpcServiceFramework.Core/IO/IpcWriter.cs
+++ b/src/JKang.IpcServiceFramework.Core/IO/IpcWriter.cs
@@ -27,14 +27,14 @@ namespace JKang.IpcServiceFramework.IO
             CancellationToken cancellationToken = default(CancellationToken))
         {
             byte[] binary = _serializer.SerializeRequest(request);
-            await WriteMessageAsync(binary, cancellationToken);
+            await WriteMessageAsync(binary, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task WriteAsync(IpcResponse response,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             byte[] binary = _serializer.SerializeResponse(response);
-            await WriteMessageAsync(binary, cancellationToken);
+            await WriteMessageAsync(binary, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task WriteMessageAsync(byte[] binary, CancellationToken cancellationToken)
@@ -45,8 +45,8 @@ namespace JKang.IpcServiceFramework.IO
             _lengthBuffer[2] = (byte)(length >> 16);
             _lengthBuffer[3] = (byte)(length >> 24);
 
-            await _stream.WriteAsync(_lengthBuffer, 0, _lengthBuffer.Length, cancellationToken);
-            await _stream.WriteAsync(binary, 0, binary.Length, cancellationToken);
+            await _stream.WriteAsync(_lengthBuffer, 0, _lengthBuffer.Length, cancellationToken).ConfigureAwait(false);
+            await _stream.WriteAsync(binary, 0, binary.Length, cancellationToken).ConfigureAwait(false);
         }
 
         #region IDisposible

--- a/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
@@ -58,7 +58,7 @@ namespace JKang.IpcServiceFramework
                     IpcResponse response;
                     using (IServiceScope scope = ServiceProvider.CreateScope())
                     {
-                        response = await GetReponse(request, scope);
+                        response = await GetReponse(request, scope).ConfigureAwait(false);
                     }
 
                     cancellationToken.ThrowIfCancellationRequested();
@@ -71,7 +71,7 @@ namespace JKang.IpcServiceFramework
                 catch (Exception ex)
                 {
                     logger?.LogError(ex, ex.Message);
-                    await writer.WriteAsync(IpcResponse.Fail($"Internal server error: {ex.Message}"), cancellationToken);
+                    await writer.WriteAsync(IpcResponse.Fail($"Internal server error: {ex.Message}"), cancellationToken).ConfigureAwait(false);
                 }
             }
         }
@@ -133,7 +133,7 @@ namespace JKang.IpcServiceFramework
 
                 if (@return is Task)
                 {
-                    await (Task)@return;
+                    await ((Task)@return).ConfigureAwait(false);
 
                     var resultProperty = @return.GetType().GetProperty("Result");
                     return IpcResponse.Success(resultProperty?.GetValue(@return));

--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
@@ -94,7 +94,7 @@ namespace JKang.IpcServiceFramework.Tcp
                     _logger.LogDebug($"Endpoint '{Name}' listening on port {Port}...");
                     while (true)
                     {
-                        TcpClient client = await _listener.AcceptTcpClientAsync();
+                        TcpClient client = await _listener.AcceptTcpClientAsync().ConfigureAwait(false);
 
                         Stream server = client.GetStream();
 
@@ -112,7 +112,7 @@ namespace JKang.IpcServiceFramework.Tcp
                             server = ssl;
                         }
 
-                        await ProcessAsync(server, _logger, cancellationToken);
+                        await ProcessAsync(server, _logger, cancellationToken).ConfigureAwait(false);
                     }
                 }
                 catch when (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
… deadlock issues

Works nicely,
tests all ran through, I did not add configure awaits to the tests,
this fixes problems when using this library in UI applications

Please ensure normal ones are unaffected