### PR TITLE
Include method argument types to prevent GetMethod() AmbiguousMatchException

### DIFF
--- a/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
@@ -119,11 +119,19 @@ namespace JKang.IpcServiceFramework
             Delegate @delegate = lamdaExp.Compile();
             @delegate.DynamicInvoke(proxy);
 
-            return new IpcRequest
+            Type[] arguments = new Type[interceptor.LastInvocation.Arguments.Length];
+
+            for (int i = 0; i < interceptor.LastInvocation.Arguments.Length; i++)
+            {
+                arguments[i] = interceptor.LastInvocation.Arguments[i].GetType();
+            }
+
+            return new IpcRequest()
             {
                 MethodName = interceptor.LastInvocation.Method.Name,
                 Parameters = interceptor.LastInvocation.Arguments,
                 GenericArguments = interceptor.LastInvocation.GenericArguments,
+                ArgumentTypes = arguments
             };
         }
 

--- a/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
@@ -123,7 +123,16 @@ namespace JKang.IpcServiceFramework
 
             for (int i = 0; i < interceptor.LastInvocation.Arguments.Length; i++)
             {
-                arguments[i] = interceptor.LastInvocation.Arguments[i].GetType();
+                if (interceptor.LastInvocation.Arguments[i] != null)
+                {
+                    arguments[i] = interceptor.LastInvocation.Arguments[i].GetType();
+                }
+                else
+                {
+                    // If any argument is null, we cannot lookup the Method with parameter types
+                    arguments = Type.EmptyTypes;
+                    break;
+                }
             }
 
             return new IpcRequest()

--- a/src/JKang.IpcServiceFramework.Core/IpcRequest.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcRequest.cs
@@ -5,9 +5,15 @@ namespace JKang.IpcServiceFramework
     public class IpcRequest
     {
         private Type[] _genericArguments = new Type[0];
+        private Type[] _arguments = new Type[0];
 
         public string MethodName { get; set; }
         public object[] Parameters { get; set; }
+        public Type[] ArgumentTypes
+        {
+            get => _arguments ?? System.Type.EmptyTypes;
+            set => _arguments = value;
+        }
         public Type[] GenericArguments
         {
             get => _genericArguments ?? new Type[0];

--- a/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
@@ -84,10 +84,17 @@ namespace JKang.IpcServiceFramework
                 return IpcResponse.Fail($"No implementation of interface '{typeof(TContract).FullName}' found.");
             }
 
-            MethodInfo method = service.GetType().GetMethod(request.MethodName);
+            // First try to find the method with arguments
+            MethodInfo method = service.GetType().GetMethod(request.MethodName, request.ArgumentTypes);
             if (method == null)
             {
-                return IpcResponse.Fail($"Method '{request.MethodName}' not found in interface '{typeof(TContract).FullName}'.");
+                // If no match found, try again without arguments
+                method = service.GetType().GetMethod(request.MethodName);
+
+                if (method == null)
+                {
+                    return IpcResponse.Fail($"Method '{request.MethodName}' not found in interface '{typeof(TContract).FullName}'.");
+                }
             }
 
             ParameterInfo[] paramInfos = method.GetParameters();


### PR DESCRIPTION
If the IPC interface includes overloaded methods, an AmbiguousMatchException is thrown by Type.GetMethod(string) in IpcServiceEndpoint.GetReponse(), as it cannot resolve which method to use for the IPC request.

By passing the method's argument types as part of the IpcRequest, an overloaded method can be properly resolved by the service.