### PR TITLE
Corrected bug in TCP connection semantics

### DIFF
--- a/src/JKang.IpcServiceFramework.Client/Tcp/CancellableStream.cs
+++ b/src/JKang.IpcServiceFramework.Client/Tcp/CancellableStream.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace JKang.IpcServiceFramework.Tcp
+{
+    internal class CancellableStream : Stream
+    {
+        Stream _wrapped;
+        CancellationToken _cancellationToken;
+        CancellationTokenRegistration _cancellationRegistration;
+
+        public CancellableStream(Stream toWrap, CancellationToken cancellationToken)
+        {
+            _wrapped = toWrap;
+            _cancellationToken = cancellationToken;
+            _cancellationRegistration = cancellationToken.Register(() => _wrapped.Dispose());
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _cancellationRegistration.Dispose();
+            _cancellationRegistration = default(CancellationTokenRegistration);
+
+            _cancellationToken = CancellationToken.None;
+
+            base.Dispose(disposing);
+        }
+
+        void WrapOperation(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch when (_cancellationToken.IsCancellationRequested)
+            {
+                _cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+        }
+
+        T WrapOperation<T>(Func<T> action)
+        {
+            try
+            {
+                return action();
+            }
+            catch when (_cancellationToken.IsCancellationRequested)
+            {
+                _cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+        }
+
+        async Task WrapOperationAsync(Func<Task> action)
+        {
+            try
+            {
+                await action();
+            }
+            catch when (_cancellationToken.IsCancellationRequested)
+            {
+                _cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+        }
+
+        async Task<T> WrapOperationAsync<T>(Func<Task<T>> action)
+        {
+            try
+            {
+                return await action();
+            }
+            catch when (_cancellationToken.IsCancellationRequested)
+            {
+                _cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            => WrapOperation(() => _wrapped.BeginRead(buffer, offset, count, callback, state));
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+            => WrapOperation(() => _wrapped.BeginWrite(buffer, offset, count, callback, state));
+        public override bool CanRead
+            => WrapOperation(() => _wrapped.CanRead);
+        public override bool CanSeek
+            => WrapOperation(() => _wrapped.CanSeek);
+        public override bool CanTimeout
+            => WrapOperation(() => _wrapped.CanTimeout);
+        public override bool CanWrite
+            => WrapOperation(() => _wrapped.CanWrite);
+        public override void Close()
+            => WrapOperation(() => _wrapped.Close());
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+            => WrapOperationAsync(async () => await _wrapped.CopyToAsync(destination, bufferSize, cancellationToken));
+        public override int EndRead(IAsyncResult asyncResult)
+            => WrapOperation(() => _wrapped.EndRead(asyncResult));
+        public override void EndWrite(IAsyncResult asyncResult)
+            => WrapOperation(() => _wrapped.EndWrite(asyncResult));
+        public override bool Equals(object obj)
+            => WrapOperation(() => _wrapped.Equals(obj));
+        public override void Flush()
+            => WrapOperation(() => _wrapped.Flush());
+        public override Task FlushAsync(CancellationToken cancellationToken)
+            => WrapOperationAsync(async () => await _wrapped.FlushAsync(cancellationToken));
+        public override int GetHashCode()
+            => WrapOperation(() => _wrapped.GetHashCode());
+        public override object InitializeLifetimeService()
+            => WrapOperation(() => _wrapped.InitializeLifetimeService());
+        public override long Length
+            => WrapOperation(() => _wrapped.Length);
+        public override long Position
+        {
+            get => WrapOperation(() => _wrapped.Position);
+            set => WrapOperation(() => _wrapped.Position = value);
+        }
+        public override int Read(byte[] buffer, int offset, int count)
+            => WrapOperation(() => _wrapped.Read(buffer, offset, count));
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => WrapOperationAsync(() => _wrapped.ReadAsync(buffer, offset, count, cancellationToken));
+        public override int ReadByte()
+            => WrapOperation(() => _wrapped.ReadByte());
+        public override int ReadTimeout
+        {
+            get => WrapOperation(() => _wrapped.ReadTimeout);
+            set => WrapOperation(() => _wrapped.ReadTimeout = value);
+        }
+        public override long Seek(long offset, SeekOrigin origin)
+            => WrapOperation(() => _wrapped.Seek(offset, origin));
+        public override void SetLength(long value)
+            => WrapOperation(() => _wrapped.SetLength(value));
+        public override string ToString()
+            => WrapOperation(() => _wrapped.ToString());
+        public override void Write(byte[] buffer, int offset, int count)
+            => WrapOperation(() => _wrapped.Write(buffer, offset, count));
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => WrapOperation(() => _wrapped.WriteAsync(buffer, offset, count, cancellationToken));
+        public override void WriteByte(byte value)
+            => WrapOperation(() => _wrapped.WriteByte(value));
+        public override int WriteTimeout
+        {
+            get => WrapOperation(() => _wrapped.WriteTimeout);
+            set => WrapOperation(() => _wrapped.WriteTimeout = value);
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.Client/Tcp/TcpClientExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Client/Tcp/TcpClientExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace JKang.IpcServiceFramework.Tcp
+{
+    internal static class TcpClientExtensions
+    {
+        public static Task ConnectAsync(this TcpClient client, string host, int port) => ConnectAsyncImpl(client, () => client.BeginConnect(host, port, null, null), CancellationToken.None);
+        public static Task ConnectAsync(this TcpClient client, IPAddress address, int port) => ConnectAsyncImpl(client, () => client.BeginConnect(address, port, null, null), CancellationToken.None);
+        public static Task ConnectAsync(this TcpClient client, IPEndPoint remoteEP) => ConnectAsyncImpl(client, () => client.BeginConnect(remoteEP.Address, remoteEP.Port, null, null), CancellationToken.None);
+        public static Task ConnectAsync(this TcpClient client, IPAddress[] addresses, int port) => ConnectAsyncImpl(client, () => client.BeginConnect(addresses, port, null, null), CancellationToken.None);
+
+        public static Task ConnectAsync(this TcpClient client, string host, int port, CancellationToken cancellationToken) => ConnectAsyncImpl(client, () => client.BeginConnect(host, port, null, null), cancellationToken);
+        public static Task ConnectAsync(this TcpClient client, IPAddress address, int port, CancellationToken cancellationToken) => ConnectAsyncImpl(client, () => client.BeginConnect(address, port, null, null), cancellationToken);
+        public static Task ConnectAsync(this TcpClient client, IPEndPoint remoteEP, CancellationToken cancellationToken) => ConnectAsyncImpl(client, () => client.BeginConnect(remoteEP.Address, remoteEP.Port, null, null), cancellationToken);
+        public static Task ConnectAsync(this TcpClient client, IPAddress[] addresses, int port, CancellationToken cancellationToken) => ConnectAsyncImpl(client, () => client.BeginConnect(addresses, port, null, null), cancellationToken);
+
+        static async Task ConnectAsyncImpl(TcpClient client, Func<IAsyncResult> beginConnect, CancellationToken cancellationToken)
+        {
+            var asyncResult = beginConnect();
+
+            CancellationTokenRegistration tokenRegistration = default(CancellationTokenRegistration);
+            RegisteredWaitHandle waitHandleRegistration = null;
+
+            var completionSource = new TaskCompletionSource<bool>();
+
+            try
+            {
+                waitHandleRegistration = ThreadPool.RegisterWaitForSingleObject(
+                    asyncResult.AsyncWaitHandle,
+                    (state, timeout) => completionSource.SetResult(!timeout),
+                    null,
+                    Timeout.Infinite,
+                    executeOnlyOnce: true);
+
+                tokenRegistration = cancellationToken.Register(() => client.Close());
+
+                await completionSource.Task;
+            }
+            finally
+            {
+                waitHandleRegistration?.Unregister(asyncResult.AsyncWaitHandle);
+                tokenRegistration.Dispose();
+            }
+
+            try
+            {
+                client.EndConnect(asyncResult);
+            }
+            catch when (cancellationToken.IsCancellationRequested)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.Client/Tcp/TcpIpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/Tcp/TcpIpcServiceClient.cs
@@ -72,13 +72,11 @@ namespace JKang.IpcServiceFramework.Tcp
                 // poll every 100ms to check cancellation request
                 while (!result.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(100), false))
                 {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        client.EndConnect(result);
-                        cancellationToken.ThrowIfCancellationRequested();
-                    }
+                    cancellationToken.ThrowIfCancellationRequested();
                 }
             }).ConfigureAwait(false);
+
+            client.EndConnect(result);
 
             cancellationToken.Register(() =>
             {


### PR DESCRIPTION
I have encountered a problem with initiating TCP connections. Sometimes, connection attempts fail with the error message:

    The operation is not allowed on non-connected sockets.

In the debugger, I found that this exception comes from the following line in `TcpIpcServiceClient.cs`:

            var client = new TcpClient();
            IAsyncResult result = client.BeginConnect(_serverIp, _serverPort, null, null);

            await Task.Run(() =>
            {
                // poll every 100ms to check cancellation request
                while (!result.AsyncWaitHandle.WaitOne(TimeSpan.FromMilliseconds(100), false))
                {
                    if (cancellationToken.IsCancellationRequested)
                    {
                        client.EndConnect(result);
                        cancellationToken.ThrowIfCancellationRequested();
                    }
                }
            }).ConfigureAwait(false);

            cancellationToken.Register(() =>
            {
                client.Close();
            });

    >>>>    Stream stream = client.GetStream();

I believe that this is resulting from the "successful" flow never calling `client.EndConnect` on the `IAsyncResult`. I hypothesize that this code was written with an incorrect understanding of what the `EndConnect` method does. It does not terminate the attempt to connect -- rather, it joins (waits for) the background operation represented by the `IAsyncResult` returned by `BeginConnect`, and is an essential part of the `IAsyncResult` asynchronous operation pattern. (When you have a `Begin`/`End` method pair, the `End` method is where return values are returned and exceptions that occurred during the background operation get thrown.)

As written, with `EndConnect` being called when cancellation is requested, the act of requesting cancellation will actually cause it to block until the TCP connection attempt is resolved, whether successful or not, which is the opposite of the desired effect.

This PR moves the `EndConnect` call to a point in the code where we expect the connection attempt to be successful. This is actually an essential part of the `Begin`/`End` `IAsyncResult` pattern, and allows the `Socket` the opportunity to properly complete the connection operation. Conversely, if cancellation is requested, then the `IAsyncOperation` is simply abandoned and an exception is thrown immediately.