### PR TITLE
 Adding new attribute 'KnowType' to solve problems with the inability to create an interface or abstract class

### DIFF
--- a/src/IpcServiceSample.ConsoleClient/Program.cs
+++ b/src/IpcServiceSample.ConsoleClient/Program.cs
@@ -136,7 +136,10 @@ namespace IpcServiceSample.ConsoleClient
             // test 14: use a translated stream to log data to a text file
             generatedId = await loggedClient.InvokeAsync(x => x.GenerateId(), cancellationToken);
             Console.WriteLine($"[TEST 14] Called method using stream translator for logging, generated ID is: {generatedId}");
-
+            
+            int testSum = await systemClient.InvokeAsync(x => x.TryGetInt(new Test(1)), cancellationToken);
+            Console.WriteLine($"[TEST 15] Called method which takes the interface. Result: {testSum}");
+            
             Console.WriteLine("All test finished. Press any key to exit.");
         }
     }

--- a/src/IpcServiceSample.ConsoleClient/Program.cs
+++ b/src/IpcServiceSample.ConsoleClient/Program.cs
@@ -136,10 +136,10 @@ namespace IpcServiceSample.ConsoleClient
             // test 14: use a translated stream to log data to a text file
             generatedId = await loggedClient.InvokeAsync(x => x.GenerateId(), cancellationToken);
             Console.WriteLine($"[TEST 14] Called method using stream translator for logging, generated ID is: {generatedId}");
-            
+
             int testSum = await systemClient.InvokeAsync(x => x.TryGetInt(new Test(1)), cancellationToken);
             Console.WriteLine($"[TEST 15] Called method which takes the interface. Result: {testSum}");
-            
+
             Console.WriteLine("All test finished. Press any key to exit.");
         }
     }

--- a/src/IpcServiceSample.ConsoleServer/SystemService.cs
+++ b/src/IpcServiceSample.ConsoleServer/SystemService.cs
@@ -43,7 +43,7 @@ namespace IpcServiceSample.ConsoleServer
         {
             Thread.Sleep(10000);
         }
-
+        
         public int TryGetInt(ITest test)
         {
             return test.Sum;

--- a/src/IpcServiceSample.ConsoleServer/SystemService.cs
+++ b/src/IpcServiceSample.ConsoleServer/SystemService.cs
@@ -43,5 +43,10 @@ namespace IpcServiceSample.ConsoleServer
         {
             Thread.Sleep(10000);
         }
+
+        public int TryGetInt(ITest test)
+        {
+            return test.Sum;
+        }
     }
 }

--- a/src/IpcServiceSample.ServiceContracts/ISystemService.cs
+++ b/src/IpcServiceSample.ServiceContracts/ISystemService.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JKang.IpcServiceFramework.Services;
 
 namespace IpcServiceSample.ServiceContracts
 {
@@ -10,5 +11,12 @@ namespace IpcServiceSample.ServiceContracts
         byte[] ReverseBytes(byte[] input);
         string Printout<T>(T value);
         void SlowOperation();
+        int TryGetInt(ITest test);
+    }
+    
+    [KnowType(typeof(Test))]
+    public interface ITest
+    {
+        int Sum { get; }     
     }
 }

--- a/src/IpcServiceSample.ServiceContracts/IpcServiceSample.ServiceContracts.csproj
+++ b/src/IpcServiceSample.ServiceContracts/IpcServiceSample.ServiceContracts.csproj
@@ -1,8 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>IpcServiceSample.ServiceContracts</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\JKang.IpcServiceFramework.Core\JKang.IpcServiceFramework.Core.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/IpcServiceSample.ServiceContracts/IpcServiceSample.ServiceContracts.csproj
+++ b/src/IpcServiceSample.ServiceContracts/IpcServiceSample.ServiceContracts.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\JKang.IpcServiceFramework.Core\JKang.IpcServiceFramework.Core.csproj" />
   </ItemGroup>
 

--- a/src/IpcServiceSample.ServiceContracts/Test.cs
+++ b/src/IpcServiceSample.ServiceContracts/Test.cs
@@ -1,0 +1,25 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace IpcServiceSample.ServiceContracts
+{
+    public class Test : ITest
+    {
+        private int _sum;
+
+        public int Sum => _sum;
+
+        public Test(int sum)
+        {
+            _sum = sum;
+        }
+    }
+
+    [KnownType(typeof(ITest))]
+    public abstract class TestT : ITest
+    {
+        private int _sum;
+
+        public int Sum => _sum;
+    }
+}

--- a/src/JKang.IpcServiceFramework.Core/Services/DefaultValueConverter.cs
+++ b/src/JKang.IpcServiceFramework.Core/Services/DefaultValueConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Linq;
 
 namespace JKang.IpcServiceFramework.Services
 {
@@ -14,7 +15,7 @@ namespace JKang.IpcServiceFramework.Services
                 return destType.IsClass || (Nullable.GetUnderlyingType(destType) != null);
             }
 
-            if (destType.IsAssignableFrom(origValue.GetType()))
+            if (destType.IsInstanceOfType(origValue))
             {
                 // copy value directly if it can be assigned to destType
                 destValue = origValue;
@@ -56,7 +57,16 @@ namespace JKang.IpcServiceFramework.Services
 
             if (origValue is JObject jObj)
             {
-                // rely on JSON.Net to convert complexe type
+                if (destType.IsInterface || (destType.IsClass && destType.IsAbstract))
+                {
+                    KnowType kT = (KnowType) Attribute.GetCustomAttributes(destType).First(x => x.GetType() == typeof(KnowType));
+                    if (kT != null)
+                    {
+                        destValue = jObj.ToObject(kT.Type);
+                        return true; 
+                    }
+                }
+
                 destValue = jObj.ToObject(destType);
                 // TODO: handle error
                 return true;

--- a/src/JKang.IpcServiceFramework.Core/Services/DefaultValueConverter.cs
+++ b/src/JKang.IpcServiceFramework.Core/Services/DefaultValueConverter.cs
@@ -63,7 +63,7 @@ namespace JKang.IpcServiceFramework.Services
                     if (kT != null)
                     {
                         destValue = jObj.ToObject(kT.Type);
-                        return true; 
+                        return true;
                     }
                 }
 

--- a/src/JKang.IpcServiceFramework.Core/Services/KnowType.cs
+++ b/src/JKang.IpcServiceFramework.Core/Services/KnowType.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace JKang.IpcServiceFramework.Services
+{
+    [AttributeUsage(AttributeTargets.Interface | AttributeTargets.Class)]
+    public class KnowType : Attribute
+    {
+        public Type Type { get; }
+
+        public KnowType(Type type)
+        {
+            if (type == null)
+            {
+                throw new ArgumentNullException(nameof(type));
+            }
+            
+            if (type.IsClass && !type.IsAbstract)
+            {
+                Type = type;
+            }
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
@@ -163,7 +163,7 @@ namespace JKang.IpcServiceFramework
             {
                 return null;
             }
-            
+
             MethodInfo method = null;     // disambiguate - can't just call as before with generics - MethodInfo method = service.GetType().GetMethod(request.MethodName);
             
             // Thanks https://github.com/luhis for these changes

--- a/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/IpcServiceEndpoint.cs
@@ -163,9 +163,13 @@ namespace JKang.IpcServiceFramework
             {
                 return null;
             }
-
+            
             MethodInfo method = null;     // disambiguate - can't just call as before with generics - MethodInfo method = service.GetType().GetMethod(request.MethodName);
-            var serviceMethods = service.GetType().GetMethods().Where(m => m.Name == request.MethodName);
+            
+            // Thanks https://github.com/luhis for these changes
+            var types = service.GetType().GetInterfaces();
+            var allMethods = types.SelectMany(t => t.GetMethods());
+            var serviceMethods = allMethods.Where(t => t.Name == request.MethodName).ToList();
 
             foreach (var serviceMethod in serviceMethods)
             {


### PR DESCRIPTION
Hi! When using the parameters of the interface method and the abstract class, Newtonsoft.Json throws an exception: 'Could not create an instance of type X. Type is an interface or abstract class and cannot be instantiated.'
Solve this problem can be settings JsonSerializer but why in this situation it did not solve the problem.
So I made a new attribute.
Here is an example of use:
```csharp
[KnowType(typeof(Test))]
public interface ITest
{
    int Sum { get; }     
}
```