### PR TITLE
Proper closing of TCP client connections.

### DIFF
--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
@@ -135,6 +135,7 @@ namespace JKang.IpcServiceFramework.Tcp
                         if (_throttle == null)
                         {
                             await ProcessAsync(server, _logger, cancellationToken);
+                            client.Close();
                         }
                         else
                         {
@@ -144,6 +145,7 @@ namespace JKang.IpcServiceFramework.Tcp
                                     try
                                     {
                                         await ProcessAsync(server, _logger, cancellationToken).ConfigureAwait(false);
+                                        client.Close();
                                     }
                                     catch when (cancellationToken.IsCancellationRequested) { }
                                     finally


### PR DESCRIPTION
In using the TCP endpoint, I am seeing every message finish its connection with a RESET after a garbage collection instead of gracefully closing the connection.  This pull request puts in a Close() call to allow proper closing of the TCP connection with 2 pairs of FIN-ACK's instead of the client sending a FIN-ACK and the server sending a RESET at garbage collection due to dangling server socket.