### PR TITLE
Add IncludeFailureDetailsInResponse option and supporting types

### DIFF
--- a/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcServiceClient.cs
@@ -37,7 +37,7 @@ namespace JKang.IpcServiceFramework
             }
             else
             {
-                throw new InvalidOperationException(response.Failure);
+                throw response.GetException();
             }
         }
 
@@ -60,7 +60,7 @@ namespace JKang.IpcServiceFramework
             }
             else
             {
-                throw new InvalidOperationException(response.Failure);
+                throw response.GetException();
             }
         }
 
@@ -76,7 +76,7 @@ namespace JKang.IpcServiceFramework
             }
             else
             {
-                throw new InvalidOperationException(response.Failure);
+                throw response.GetException();
             }
         }
 
@@ -99,7 +99,7 @@ namespace JKang.IpcServiceFramework
             }
             else
             {
-                throw new InvalidOperationException(response.Failure);
+                throw response.GetException();
             }
         }
 

--- a/src/JKang.IpcServiceFramework.Core/IpcResponse.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace JKang.IpcServiceFramework
@@ -6,25 +7,76 @@ namespace JKang.IpcServiceFramework
     public class IpcResponse
     {
         [JsonConstructor]
-        private IpcResponse(bool succeed, object data, string failure)
+        private IpcResponse(bool succeed, object data, string failure, string failureDetails, bool userCodeFailure)
         {
             Succeed = succeed;
             Data = data;
             Failure = failure;
+            FailureDetails = failureDetails;
+            UserCodeFailure = userCodeFailure;
         }
 
         public static IpcResponse Fail(string failure)
         {
-            return new IpcResponse(false, null, failure);
+            return new IpcResponse(false, null, failure, null, false);
+        }
+
+        public static IpcResponse Fail(Exception ex, bool includeDetails, bool userFailure = false)
+        {
+            string message = null;
+            string details = null;
+
+            if (!userFailure)
+            {
+                message = "Internal server error: ";
+            }
+
+            message += GetFirstUsableMessage(ex);
+
+            if (includeDetails)
+            {
+                details = ex.ToString();
+            }
+
+            return new IpcResponse(false, null, message, details, userFailure);
         }
 
         public static IpcResponse Success(object data)
         {
-            return new IpcResponse(true, data, null);
+            return new IpcResponse(true, data, null, null, false);
         }
 
         public bool Succeed { get; }
         public object Data { get; }
         public string Failure { get; }
+        public string FailureDetails { get; }
+        public bool UserCodeFailure { get; set; }
+
+        public Exception GetException()
+        {
+            if (UserCodeFailure)
+            {
+                throw new IpcServerUserCodeException(Failure, FailureDetails);
+            }
+
+            throw new IpcServerException(Failure, FailureDetails);
+        }
+
+        private static string GetFirstUsableMessage(Exception ex)
+        {
+            var e = ex;
+
+            while (e != null)
+            {
+                if (!(e is TargetInvocationException))
+                {
+                    return e.Message;
+                }
+
+                e = e.InnerException;
+            }
+
+            return ex.Message;
+        }
     }
 }

--- a/src/JKang.IpcServiceFramework.Core/IpcServerException.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcServerException.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace JKang.IpcServiceFramework
+{
+    /// <summary>
+    /// An exception that originated at the server.
+    /// </summary>
+    [Serializable]
+    public class IpcServerException : InvalidOperationException
+    {
+        public const string ServerFailureDetails = "Server failure details:";
+        public string FailureDetails { get; }
+
+        public IpcServerException()
+        {
+        }
+
+        public IpcServerException(string message, string failureDetails)
+            : base(message)
+        {
+            FailureDetails = failureDetails;
+        }
+
+        public IpcServerException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected IpcServerException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
+            FailureDetails = info.GetString("FailureDetails");
+        }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            info.AddValue("FailureDetails", FailureDetails, typeof(string));
+        }
+
+        public override string ToString()
+        {
+            if (!string.IsNullOrWhiteSpace(FailureDetails))
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine(base.ToString());
+                sb.AppendLine();
+                sb.AppendLine(ServerFailureDetails);
+                sb.Append(FailureDetails);
+                return sb.ToString();
+            }
+
+            return base.ToString();
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.Core/IpcServerUserCodeException.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcServerUserCodeException.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace JKang.IpcServiceFramework
+{
+    /// <summary>
+    /// An exception that originated at the server, in user code.
+    /// </summary>
+    [Serializable]
+    public class IpcServerUserCodeException : IpcServerException
+    {
+        public IpcServerUserCodeException()
+        {
+        }
+
+        public IpcServerUserCodeException(string message, string failureDetails)
+            : base(message, failureDetails)
+        {
+        }
+
+        public IpcServerUserCodeException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        protected IpcServerUserCodeException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.IntegrationTests/ContractTest.cs
+++ b/src/JKang.IpcServiceFramework.IntegrationTests/ContractTest.cs
@@ -98,6 +98,20 @@ namespace JKang.IpcServiceFramework.IntegrationTests
             Assert.True(actual >= 450);
         }
 
+        [Fact]
+        public async Task ThrowException()
+        {
+            try
+            {
+                await _client.InvokeAsync(x => x.ThrowException("This was forced"));
+            }
+            catch (IpcServerException ex)
+            {
+                Assert.Contains("This was forced", ex.Message);
+                Assert.DoesNotContain(IpcServerException.ServerFailureDetails, ex.ToString());
+            }
+        }
+
         public void Dispose()
         {
             _cancellationToken.Cancel();

--- a/src/JKang.IpcServiceFramework.IntegrationTests/FailureDetailTest.cs
+++ b/src/JKang.IpcServiceFramework.IntegrationTests/FailureDetailTest.cs
@@ -1,0 +1,60 @@
+using AutoFixture.Xunit2;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace JKang.IpcServiceFramework.IntegrationTests
+{
+    public class FailureDetailTest : IDisposable
+    {
+        private readonly CancellationTokenSource _cancellationToken;
+        private readonly int _port;
+        private readonly IpcServiceClient<ITestService> _client;
+
+        public FailureDetailTest()
+        {
+            // configure DI
+            IServiceCollection services = new ServiceCollection()
+                .AddIpc(builder => builder.AddNamedPipe().AddService<ITestService, TestService>());
+            _port = new Random().Next(10000, 50000);
+            IIpcServiceHost host = new IpcServiceHostBuilder(services.BuildServiceProvider())
+                .AddTcpEndpoint<ITestService>(
+                    name: Guid.NewGuid().ToString(),
+                    ipEndpoint: IPAddress.Loopback,
+                    port: _port,
+                    includeFailureDetailsInResponse: true)
+                .Build();
+            _cancellationToken = new CancellationTokenSource();
+            host.RunAsync(_cancellationToken.Token);
+
+            _client = new IpcServiceClientBuilder<ITestService>()
+                .UseTcp(IPAddress.Loopback, _port)
+                .Build();
+        }
+
+        [Fact]
+        public async Task ThrowException()
+        {
+            try
+            {
+                await _client.InvokeAsync(x => x.ThrowException("This was forced"));
+            }
+            catch (IpcServerException ex)
+            {
+                Assert.Contains("This was forced", ex.Message);
+                Assert.Contains(IpcServerException.ServerFailureDetails, ex.ToString());
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellationToken.Cancel();
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.IntegrationTests/ITestService.cs
+++ b/src/JKang.IpcServiceFramework.IntegrationTests/ITestService.cs
@@ -16,5 +16,6 @@ namespace JKang.IpcServiceFramework.IntegrationTests
         byte[] ReverseBytes(byte[] input);
         T GetDefaultValue<T>();
         Task<long> WaitAsync(int milliseconds);
+        void ThrowException(string message);
     }
 }

--- a/src/JKang.IpcServiceFramework.IntegrationTests/TestService.cs
+++ b/src/JKang.IpcServiceFramework.IntegrationTests/TestService.cs
@@ -53,5 +53,10 @@ namespace JKang.IpcServiceFramework.IntegrationTests
             await Task.Delay(milliseconds);
             return sw.ElapsedMilliseconds;
         }
+
+        public void ThrowException(string message)
+        {
+            throw new Exception(message);
+        }
     }
 }

--- a/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceEndpoint.cs
@@ -13,8 +13,8 @@ namespace JKang.IpcServiceFramework.NamedPipe
         private readonly ILogger<NamedPipeIpcServiceEndpoint<TContract>> _logger;
         private readonly NamedPipeOptions _options;
 
-        public NamedPipeIpcServiceEndpoint(string name, IServiceProvider serviceProvider, string pipeName)
-            : base(name, serviceProvider)
+        public NamedPipeIpcServiceEndpoint(string name, IServiceProvider serviceProvider, string pipeName, bool includeFailureDetailsInResponse = false)
+            : base(name, serviceProvider, includeFailureDetailsInResponse)
         {
             PipeName = pipeName;
 

--- a/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceHostBuilderExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceHostBuilderExtensions.cs
@@ -5,10 +5,11 @@ namespace JKang.IpcServiceFramework
     public static class NamedPipeIpcServiceHostBuilderExtensions
     {
         public static IpcServiceHostBuilder AddNamedPipeEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, string pipeName)
+            string name, string pipeName, bool includeFailureDetailsInResponse = false)
             where TContract: class
         {
-            return builder.AddEndpoint(new NamedPipeIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, pipeName));
+            return builder.AddEndpoint(new NamedPipeIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, pipeName,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
     }
 }

--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceEndpoint.cs
@@ -25,8 +25,8 @@ namespace JKang.IpcServiceFramework.Tcp
         private readonly X509Certificate _serverCertificate;
         private readonly int _maximumConcurrentCalls;
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, TcpConcurrencyOptions concurrencyOptions)
-            : base(name, serviceProvider)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : base(name, serviceProvider, includeFailureDetailsInResponse)
         {
             if (concurrencyOptions == null)
                 _maximumConcurrentCalls = 1;
@@ -43,45 +43,45 @@ namespace JKang.IpcServiceFramework.Tcp
             Port = port;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions, includeFailureDetailsInResponse)
         {
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions, includeFailureDetailsInResponse)
         {
             _streamTranslator = streamTranslator;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, 0, concurrencyOptions, includeFailureDetailsInResponse)
         {
             _serverCertificate = sslCertificate;
             SSL = true;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, sslCertificate, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, sslCertificate, concurrencyOptions, includeFailureDetailsInResponse)
         {
             _streamTranslator = streamTranslator;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, port, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, port, concurrencyOptions, includeFailureDetailsInResponse)
         {
             _streamTranslator = streamTranslator;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, port, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, port, concurrencyOptions, includeFailureDetailsInResponse)
         {
             _serverCertificate = sslCertificate;
             SSL = true;
         }
 
-        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
-            : this(name, serviceProvider, ipEndpoint, port, sslCertificate, concurrencyOptions)
+        public TcpIpcServiceEndpoint(String name, IServiceProvider serviceProvider, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions, bool includeFailureDetailsInResponse = false)
+            : this(name, serviceProvider, ipEndpoint, port, sslCertificate, concurrencyOptions, includeFailureDetailsInResponse)
         {
             _streamTranslator = streamTranslator;
         }

--- a/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceHostBuilderExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Server/Tcp/TcpIpcServiceHostBuilderExtensions.cs
@@ -9,115 +9,139 @@ namespace JKang.IpcServiceFramework
     public static class TcpIpcServiceHostBuilderExtensions
     {
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint)
+            string name, IPAddress ipEndpoint, bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
             return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port)
+            string name, IPAddress ipEndpoint, int port, bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, int port, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, concurrencyOptions));
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, concurrencyOptions,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator)
+            string name, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, streamTranslator, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, streamTranslator, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, streamTranslator, concurrencyOptions));
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, streamTranslator, concurrencyOptions,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, X509Certificate sslCertificate)
+            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, sslCertificate, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, sslCertificate, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, concurrencyOptions));
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, concurrencyOptions,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator)
+            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, sslCertificate, streamTranslator, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, sslCertificate, streamTranslator, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, streamTranslator, concurrencyOptions));
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, sslCertificate, streamTranslator, concurrencyOptions,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate)
+            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, sslCertificate, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, sslCertificate, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, concurrencyOptions));
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, concurrencyOptions,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator)
+            string name, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, streamTranslator, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, streamTranslator, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, int port, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
             return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, streamTranslator, concurrencyOptions));
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator)
+            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, sslCertificate, streamTranslator, concurrencyOptions: null);
+            return builder.AddTcpEndpoint<TContract>(name, ipEndpoint, port, sslCertificate, streamTranslator, concurrencyOptions: null,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse);
         }
 
         public static IpcServiceHostBuilder AddTcpEndpoint<TContract>(this IpcServiceHostBuilder builder,
-            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions)
+            string name, IPAddress ipEndpoint, int port, X509Certificate sslCertificate, Func<Stream, Stream> streamTranslator, TcpConcurrencyOptions concurrencyOptions,
+            bool includeFailureDetailsInResponse = false)
             where TContract : class
         {
-            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, streamTranslator, concurrencyOptions));
+            return builder.AddEndpoint(new TcpIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, ipEndpoint, port, sslCertificate, streamTranslator, concurrencyOptions,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
     }
 }


### PR DESCRIPTION
This PR introduces the new option IncludeFailureDetailsInResponse on endpoints. Setting this to true, will include failure details in the IpcResponse object (and thus make them available on the client side) - if you know "IncludeExceptionDetailsInFault" from WCF, this is the same idea.

If you want (and you might not, hence the default remains "false" for security reasons) to display the detailed server stack trace on the client, you can set this option to true, when creating the endpoints.

For the purpose of properly transmitting such information new fields have been added to IpcResponse (especially FailureDetails, but others as well). On the client side the typical exception being raised for "IpcResponse.Succeed == false" is no longer a simple InvalidOperationException, but an IpcServerException or an IpcServerUserCodeException. Both derive from InvalidOperationException, so user code handling these remains compatible. But both have the additional field FailureDetails,
which contains said details. Additionally the ToString() method of either includes the failure details, if available.

These new exception types additionally have the benefit, that user (client) code can easily distinguish between errors that really originated on the server and even if they originated in server infrastructure code (IpcServerException) or in server side user code (IpcServerUserCodeException).

