### PR TITLE
Add option to give a name to NamedPipe listener threads

### DIFF
--- a/src/JKang.IpcServiceFramework.Core/IO/IpcReader.cs
+++ b/src/JKang.IpcServiceFramework.Core/IO/IpcReader.cs
@@ -41,7 +41,7 @@ namespace JKang.IpcServiceFramework.IO
 
             if (headerLength != 4)
             {
-                throw new ArgumentOutOfRangeException($"Header length must be 4 but was {headerLength}");
+                throw new IpcReadException("Header", _lengthBuffer.Length, headerLength);
             }
 
             int expectedLength = _lengthBuffer[0] | _lengthBuffer[1] << 8 | _lengthBuffer[2] << 16 | _lengthBuffer[3] << 24;
@@ -70,7 +70,7 @@ namespace JKang.IpcServiceFramework.IO
 
             if (totalBytesReceived != expectedLength)
             {
-                throw new System.ArgumentOutOfRangeException($"Data length must be {expectedLength} but was {totalBytesReceived}");
+                throw new IpcReadException("Data", expectedLength, totalBytesReceived);
             }
 
             return bytes;

--- a/src/JKang.IpcServiceFramework.Core/IpcReadException.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcReadException.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+
+namespace JKang.IpcServiceFramework
+{
+    [Serializable]
+    public class IpcReadException : IOException
+    {
+        public IpcReadException()
+        {
+        }
+
+        public IpcReadException(string message)
+            : base(message)
+        {
+        }
+
+        public IpcReadException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+        public IpcReadException(string element, int expectedBytes, int readBytes)
+            : base(string.Format(CultureInfo.InvariantCulture,"{0} length must be {1} but was {2}",
+                element, expectedBytes, readBytes))
+        {
+            ExpectedBytes = expectedBytes;
+            ReadBytes = readBytes;
+        }
+
+        protected IpcReadException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
+            ExpectedBytes = info.GetInt32("ExpectedBytes");
+            ReadBytes = info.GetInt32("ReadBytes");
+        }
+
+        public int ExpectedBytes { get; }
+        public int ReadBytes { get; }
+
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+
+            info.AddValue("ExpectedBytes", ExpectedBytes, typeof(int));
+            info.AddValue("ReadBytes", ReadBytes, typeof(int));
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.Core/IpcServerException.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcServerException.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 namespace JKang.IpcServiceFramework
 {
+
     /// <summary>
     /// An exception that originated at the server.
     /// </summary>

--- a/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceEndpoint.cs
@@ -33,6 +33,10 @@ namespace JKang.IpcServiceFramework.NamedPipe
             {
                 threads[i] = new Thread((a) => { StartServerThread(a).ConfigureAwait(false).GetAwaiter().GetResult(); });
                 threads[i].Start(cancellationToken);
+                if (options.UseThreadNames)
+                {
+                    threads[i].Name = PipeName + ":" + i;
+                }
             }
 
             return Task.Factory.StartNew(() =>
@@ -49,6 +53,10 @@ namespace JKang.IpcServiceFramework.NamedPipe
                             // thread is finished, starting a new thread
                             threads[i] = new Thread((a) => { StartServerThread(a).ConfigureAwait(false).GetAwaiter().GetResult(); });
                             threads[i].Start(cancellationToken);
+                            if (options.UseThreadNames)
+                            {
+                                threads[i].Name = PipeName + ":" + i;
+                            }
                         }
                     }
                 }

--- a/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeOptions.cs
+++ b/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeOptions.cs
@@ -3,5 +3,6 @@
     public class NamedPipeOptions
     {
         public int ThreadCount { get; set; } = 4;
+        public bool UseThreadNames { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the NamedPipeOptions.UseThreadNames property. When set to true, it assigns a unique name (PipeName + ":" + ThreadIndex) to each worker thread that listens on the named pipe. This allows for easier debugging.