### PR TITLE
Expand stream translator support to named pipe services

### DIFF
--- a/src/IpcServiceSample.ConsoleClient/Program.cs
+++ b/src/IpcServiceSample.ConsoleClient/Program.cs
@@ -57,6 +57,10 @@ namespace IpcServiceSample.ConsoleClient
                 .UseNamedPipe("pipeName")
                 .Build();
 
+            IpcServiceClient<ITestService> loggedPipeClient = new IpcServiceClientBuilder<ITestService>()
+                .UseNamedPipe("testPipe", s => new LoggingStream(s, "pipeClient-ipc.log"))
+                .Build();
+
             IpcServiceClient<ISystemService> systemClient = new IpcServiceClientBuilder<ISystemService>()
                 .UseTcp(IPAddress.Loopback, 45684)
                 .Build();
@@ -129,13 +133,17 @@ namespace IpcServiceSample.ConsoleClient
             generatedId = await secureClient.InvokeAsync(x => x.GenerateId(), cancellationToken);
             Console.WriteLine($"[TEST 12] Called secure service method, generated ID is: {generatedId}");
 
-            // test 13 call translated service method
+            // test 13: call translated service method
             generatedId = await xorTranslatedClient.InvokeAsync(x => x.GenerateId(), cancellationToken);
             Console.WriteLine($"[TEST 13] Called translated service method, generated ID is: {generatedId}");
             
-            // test 14: use a translated stream to log data to a text file
+            // test 14: use a translated stream to log data to a text file (tcp client)
             generatedId = await loggedClient.InvokeAsync(x => x.GenerateId(), cancellationToken);
-            Console.WriteLine($"[TEST 14] Called method using stream translator for logging, generated ID is: {generatedId}");
+            Console.WriteLine($"[TEST 14] Called method using stream translator for logging (tcp client), generated ID is: {generatedId}");
+
+            // test 15: use a translated stream to log data to a text file (named pipe client)
+            generatedId = await loggedPipeClient.InvokeAsync(x => x.GenerateId(), cancellationToken);
+            Console.WriteLine($"[TEST 15] Called method using stream translator for logging (named pipe client), generated ID is: {generatedId}");
 
             Console.WriteLine("All test finished. Press any key to exit.");
         }

--- a/src/IpcServiceSample.ConsoleServer/Program.cs
+++ b/src/IpcServiceSample.ConsoleServer/Program.cs
@@ -21,6 +21,7 @@ namespace IpcServiceSample.ConsoleServer
             // build and run service host
             IIpcServiceHost host = new IpcServiceHostBuilder(services.BuildServiceProvider())
                 .AddNamedPipeEndpoint<IComputingService>("computingEndpoint", "pipeName")
+                .AddNamedPipeEndpoint<ITestService>("testPipeEndpoint", "testPipe", s => new LoggingStream(s, "pipeServer-ipc.log"))
                 .AddTcpEndpoint<ISystemService>("systemEndpoint", IPAddress.Loopback, 45684)
                 .AddTcpEndpoint<ITestService>("secureEndpoint", IPAddress.Loopback, 44384, new X509Certificate2(@"Certificates\server.pfx", "password"))
                 .AddTcpEndpoint<ITestService>("xorTranslatedEndpoint", IPAddress.Loopback, 45454, s => new XorStream(s))

--- a/src/JKang.IpcServiceFramework.Client/NamedPipe/NamedPipeIpcServiceClientBuilderExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Client/NamedPipe/NamedPipeIpcServiceClientBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using JKang.IpcServiceFramework.NamedPipe;
+using System;
+using System.IO;
 
 namespace JKang.IpcServiceFramework
 {
@@ -9,6 +11,16 @@ namespace JKang.IpcServiceFramework
             where TInterface : class
         {
             builder.SetFactory((serializer, converter) => new NamedPipeIpcServiceClient<TInterface>(serializer, converter, pipeName));
+
+            return builder;
+        }
+
+        public static IpcServiceClientBuilder<TInterface> UseNamedPipe<TInterface>(
+            this IpcServiceClientBuilder<TInterface> builder, string pipeName,
+            Func<Stream, Stream> streamTranslator)
+            where TInterface : class
+        {
+            builder.SetFactory((serializer, converter) => new NamedPipeIpcServiceClient<TInterface>(serializer, converter, pipeName, streamTranslator));
 
             return builder;
         }

--- a/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceHostBuilderExtensions.cs
+++ b/src/JKang.IpcServiceFramework.Server/NamedPipe/NamedPipeIpcServiceHostBuilderExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using JKang.IpcServiceFramework.NamedPipe;
+using System;
+using System.IO;
 
 namespace JKang.IpcServiceFramework
 {
@@ -6,9 +8,17 @@ namespace JKang.IpcServiceFramework
     {
         public static IpcServiceHostBuilder AddNamedPipeEndpoint<TContract>(this IpcServiceHostBuilder builder,
             string name, string pipeName, bool includeFailureDetailsInResponse = false)
-            where TContract: class
+            where TContract : class
         {
             return builder.AddEndpoint(new NamedPipeIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, pipeName,
+                includeFailureDetailsInResponse: includeFailureDetailsInResponse));
+        }
+
+        public static IpcServiceHostBuilder AddNamedPipeEndpoint<TContract>(this IpcServiceHostBuilder builder,
+            string name, string pipeName, Func<Stream, Stream> streamTranslator, bool includeFailureDetailsInResponse = false)
+            where TContract : class
+        {
+            return builder.AddEndpoint(new NamedPipeIpcServiceEndpoint<TContract>(name, builder.ServiceProvider, pipeName, streamTranslator,
                 includeFailureDetailsInResponse: includeFailureDetailsInResponse));
         }
     }


### PR DESCRIPTION
This PR adds support for using stream translators in the context of named pipe services, similar to how this is acomplished for the TCP services. This would enable the named pipes services to also make use of the LoggingStream class.

The LoggingStream class has been adapted to facilitate concurrent log writings, in the context where a NamedPipeIpcServiceEndpoint is initialized with a a ThreadCount > 1 (NamedPipeOptions). This will result in multiple NamedPipeServerStream instances attempting to write the same log file.