### PR TITLE
bugfix: only one endpoint is started when multiple ones are configured

### DIFF
--- a/src/JKang.IpcServiceFramework.Hosting/IpcBackgroundService.cs
+++ b/src/JKang.IpcServiceFramework.Hosting/IpcBackgroundService.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,13 +20,9 @@ namespace JKang.IpcServiceFramework.Hosting
             _logger = logger ?? throw new System.ArgumentNullException(nameof(logger));
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            foreach (IIpcEndpoint endpoint in _endpoints)
-            {
-                await endpoint.ExecuteAsync(stoppingToken).ConfigureAwait(false);
-            }
-            _logger.LogInformation("IPC background service started.");
+            return Task.WhenAll(_endpoints.Select(x => x.ExecuteAsync(stoppingToken)));
         }
 
         public override void Dispose()

--- a/src/JKang.IpcServiceFramework.NamedPipeTests/Fixtures/ITestService2.cs
+++ b/src/JKang.IpcServiceFramework.NamedPipeTests/Fixtures/ITestService2.cs
@@ -1,0 +1,7 @@
+﻿namespace JKang.IpcServiceFramework.NamedPipeTests.Fixtures
+{
+    public interface ITestService2
+    {
+        int SomeMethod();
+    }
+}

--- a/src/JKang.IpcServiceFramework.NamedPipeTests/MultipleEndpointTest.cs
+++ b/src/JKang.IpcServiceFramework.NamedPipeTests/MultipleEndpointTest.cs
@@ -1,0 +1,57 @@
+using AutoFixture.Xunit2;
+using JKang.IpcServiceFramework.Client;
+using JKang.IpcServiceFramework.Hosting;
+using JKang.IpcServiceFramework.NamedPipeTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace JKang.IpcServiceFramework.NamedPipeTests
+{
+    public class MultipleEndpointTest
+    {
+        [Theory, AutoData]
+        public async Task MultipleEndpoints(
+            Mock<ITestService> service1,
+            Mock<ITestService2> service2)
+        {
+            IHost host = Host.CreateDefaultBuilder()
+                .ConfigureServices(services =>
+                {
+                    services
+                        .AddScoped(x => service1.Object)
+                        .AddScoped(x => service2.Object);
+                })
+                .ConfigureIpcHost(builder =>
+                {
+                    builder
+                        .AddNamedPipeEndpoint<ITestService>("pipe1")
+                        .AddNamedPipeEndpoint<ITestService2>("pipe2");
+                })
+                .Build();
+
+            await host.StartAsync();
+
+            ServiceProvider clientServiceProvider = new ServiceCollection()
+                .AddNamedPipeIpcClient<ITestService>("client1", "pipe1")
+                .AddNamedPipeIpcClient<ITestService2>("client2", "pipe2")
+                .BuildServiceProvider();
+
+            IIpcClient<ITestService> client1 = clientServiceProvider
+                .GetRequiredService<IIpcClientFactory<ITestService>>()
+                .CreateClient("client1");
+
+            await client1.InvokeAsync(x => x.ReturnVoid());
+            service1.Verify(x => x.ReturnVoid(), Times.Once);
+
+            IIpcClient<ITestService2> client2 = clientServiceProvider
+                .GetRequiredService<IIpcClientFactory<ITestService2>>()
+                .CreateClient("client2");
+            await client2.InvokeAsync(x => x.SomeMethod());
+            service2.Verify(x => x.SomeMethod(), Times.Once);
+
+        }
+    }
+}


### PR DESCRIPTION
#118