### PR TITLE
Pipe name wasn't matching between client & server in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Named pipeline and TCP support out-of-the-box, extensible with other protocols.
                 .ConfigureIpcHost(builder =>
                 {
                     // configure IPC endpoints
-                    builder.AddNamedPipeEndpoint<IInterProcessService>(pipeName: "my-pipe");
+                    builder.AddNamedPipeEndpoint<IInterProcessService>(pipeName: "pipeinternal");
                 })
                 .ConfigureLogging(builder =>
                 {


### PR DESCRIPTION
I guess the README.md was just out if sync, it did confuse me a bit though. This is why I created a PR for this.