### PR TITLE
Bugfix for Issue #154

### DIFF
--- a/src/JKang.IpcServiceFramework.Hosting.NamedPipe/NamedPipeIpcEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Hosting.NamedPipe/NamedPipeIpcEndpoint.cs
@@ -38,7 +38,8 @@ namespace JKang.IpcServiceFramework.Hosting.NamedPipe
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 PipeSecurity pipeSecurity = new PipeSecurity();
-                PipeAccessRule psRule = new PipeAccessRule(@"Everyone", PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow);
+                SecurityIdentifier everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null);
+                PipeAccessRule psRule = new PipeAccessRule(everyone, PipeAccessRights.FullControl, System.Security.AccessControl.AccessControlType.Allow);
                 pipeSecurity.AddAccessRule(psRule);
                 using (var server = NamedPipeNative.CreateNamedPipe(_options.PipeName, (uint) _options.MaxConcurrentCalls, pipeSecurity))
                 {

--- a/src/JKang.IpcServiceFramework.Hosting.NamedPipe/NamedPipeIpcEndpoint.cs
+++ b/src/JKang.IpcServiceFramework.Hosting.NamedPipe/NamedPipeIpcEndpoint.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
The fixed name "Everyone" for creating a secure pipe works only on english Versions of windows. On other locales these User is called different. So we should use a value instead of a string.