### PR TITLE
fix: Use wrapper to ensure TcpClient and Stream are disposed together

### DIFF
--- a/src/JKang.IpcServiceFramework.Client.NamedPipe/NamedPipeIpcClient.cs
+++ b/src/JKang.IpcServiceFramework.Client.NamedPipe/NamedPipeIpcClient.cs
@@ -18,11 +18,11 @@ namespace JKang.IpcServiceFramework.Client.NamedPipe
             _options = options;
         }
 
-        protected override async Task<Stream> ConnectToServerAsync(CancellationToken cancellationToken)
+        protected override async Task<IpcStreamWrapper> ConnectToServerAsync(CancellationToken cancellationToken)
         {
             var stream = new NamedPipeClientStream(".", _options.PipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
             await stream.ConnectAsync(_options.ConnectionTimeout, cancellationToken).ConfigureAwait(false);
-            return stream;
+            return new IpcStreamWrapper(stream);
         }
     }
 }

--- a/src/JKang.IpcServiceFramework.Client/IpcClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcClient.cs
@@ -129,12 +129,12 @@ namespace JKang.IpcServiceFramework.Client
             };
         }
 
-        protected abstract Task<Stream> ConnectToServerAsync(CancellationToken cancellationToken);
+        protected abstract Task<IpcStreamWrapper> ConnectToServerAsync(CancellationToken cancellationToken);
 
         private async Task<IpcResponse> GetResponseAsync(IpcRequest request, CancellationToken cancellationToken)
         {
-            using (Stream client = await ConnectToServerAsync(cancellationToken).ConfigureAwait(false))
-            using (Stream client2 = _options.StreamTranslator == null ? client : _options.StreamTranslator(client))
+            using (IpcStreamWrapper client = await ConnectToServerAsync(cancellationToken).ConfigureAwait(false))
+            using (Stream client2 = _options.StreamTranslator == null ? client.Stream : _options.StreamTranslator(client.Stream))
             using (var writer = new IpcWriter(client2, _options.Serializer, leaveOpen: true))
             using (var reader = new IpcReader(client2, _options.Serializer, leaveOpen: true))
             {

--- a/src/JKang.IpcServiceFramework.Client/IpcStreamWrapper.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcStreamWrapper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+
+namespace JKang.IpcServiceFramework.Client
+{
+    /// <summary>
+    /// Tcp clients depend on both a TcpClient object and a Stream object.
+    /// This wrapper class ensures they are simultaneously disposed of.
+    /// </summary>
+    /// <seealso cref="System.IDisposable" />
+    public class IpcStreamWrapper : IDisposable
+    {
+        private IDisposable _context;
+        bool _disposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IpcStreamWrapper"/> class.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <param name="context">The IDisposable context the Stream depends on.</param>
+        public IpcStreamWrapper(Stream stream, IDisposable context = null)
+        {
+            Stream = stream;
+            _context = context;
+        }
+
+        public Stream Stream { get; private set; }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                _disposed = true;
+                Stream?.Dispose();
+                _context?.Dispose();
+            }
+        }
+    }
+}

--- a/src/JKang.IpcServiceFramework.TcpTests/HappyPathTest.cs
+++ b/src/JKang.IpcServiceFramework.TcpTests/HappyPathTest.cs
@@ -44,6 +44,10 @@ namespace JKang.IpcServiceFramework.TcpTests
                 .InvokeAsync(x => x.StringType(input));
 
             Assert.Equal(expected, actual);
+
+            // Execute the method again to validate the socket isn't improperly disposed
+            actual = await _client
+                .InvokeAsync(x => x.StringType(input));
         }
     }
 }


### PR DESCRIPTION
Properly Fixes #158 

By creating an IDisposable wrapper class for the TcpClient and (tcp) Stream, they are always disposed of together, fixing the issue.

