### PR TITLE
feature: Support passing Types as 'simple' names instead of Type objects, to allow for version mismatches between Client & Host assemblies

### DIFF
--- a/src/JKang.IpcServiceFramework.Client/IpcClient.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcClient.cs
@@ -100,7 +100,7 @@ namespace JKang.IpcServiceFramework.Client
             }
         }
 
-        private static IpcRequest GetRequest(Expression exp, TInterface proxy)
+        private IpcRequest GetRequest(Expression exp, TInterface proxy)
         {
             if (!(exp is LambdaExpression lambdaExp))
             {
@@ -115,18 +115,60 @@ namespace JKang.IpcServiceFramework.Client
             Delegate @delegate = lambdaExp.Compile();
             @delegate.DynamicInvoke(proxy);
 
-            return new IpcRequest
+            if (_options.UseSimpleTypeNameAssemblyFormatHandling)
             {
-                MethodName = (proxy as IpcProxy).LastInvocation.Method.Name,
-                Parameters = (proxy as IpcProxy).LastInvocation.Arguments,
+                IpcRequestParameterType[] paramByName = null;
+                IpcRequestParameterType[] genericByName = null;
 
-                ParameterTypes = (proxy as IpcProxy).LastInvocation.Method.GetParameters()
-                              .Select(p => p.ParameterType)
-                              .ToArray(),
+                var parameterTypes = (proxy as IpcProxy).LastInvocation.Method.GetParameters().Select(p => p.ParameterType);
+
+                if (parameterTypes.Any())
+                {
+                    paramByName = new IpcRequestParameterType[parameterTypes.Count()];
+                    int i = 0;
+                    foreach (var type in parameterTypes)
+                    {
+                        paramByName[i++] = new IpcRequestParameterType(type);
+                    }
+                }
+
+                var genericTypes = (proxy as IpcProxy).LastInvocation.Method.GetGenericArguments();
+
+                if (genericTypes.Length > 0)
+                {
+                    genericByName = new IpcRequestParameterType[genericTypes.Count()];
+                    int i = 0;
+                    foreach (var type in genericTypes)
+                    {
+                        genericByName[i++] = new IpcRequestParameterType(type);
+                    }
+                }
 
 
-                GenericArguments = (proxy as IpcProxy).LastInvocation.Method.GetGenericArguments(),
-            };
+                return new IpcRequest
+                {
+                    MethodName = (proxy as IpcProxy).LastInvocation.Method.Name,
+                    Parameters = (proxy as IpcProxy).LastInvocation.Arguments,
+
+                    ParameterTypesByName = paramByName,
+                    GenericArgumentsByName = genericByName
+                };
+            }
+            else
+            {
+                return new IpcRequest
+                {
+                    MethodName = (proxy as IpcProxy).LastInvocation.Method.Name,
+                    Parameters = (proxy as IpcProxy).LastInvocation.Arguments,
+
+                    ParameterTypes = (proxy as IpcProxy).LastInvocation.Method.GetParameters()
+                                  .Select(p => p.ParameterType)
+                                  .ToArray(),
+
+
+                    GenericArguments = (proxy as IpcProxy).LastInvocation.Method.GetGenericArguments(),
+                };
+            }
         }
 
         protected abstract Task<Stream> ConnectToServerAsync(CancellationToken cancellationToken);

--- a/src/JKang.IpcServiceFramework.Client/IpcClientOptions.cs
+++ b/src/JKang.IpcServiceFramework.Client/IpcClientOptions.cs
@@ -14,6 +14,17 @@ namespace JKang.IpcServiceFramework.Client
         /// </summary>
         public int ConnectionTimeout { get; set; } = 60000;
 
+        /// <summary>
+        /// Indicates the method that will be used during deserialization on the server for locating and loading assemblies.
+        /// If <c>false</c>, the assembly used during deserialization must match exactly the assembly used during serialization.
+        /// 
+        /// If <c>true</c>, the assembly used during deserialization need not match exactly the assembly used during serialization.
+        /// Specifically, the version numbers need not match.
+        /// 
+        /// Default is <c>false</c>.
+        /// </summary>
+        public bool UseSimpleTypeNameAssemblyFormatHandling { get; set; } = false;
+
         public IIpcMessageSerializer Serializer { get; set; } = new DefaultIpcMessageSerializer();
 
         public IValueConverter ValueConverter { get; set; } = new DefaultValueConverter();

--- a/src/JKang.IpcServiceFramework.Core/IpcRequest.cs
+++ b/src/JKang.IpcServiceFramework.Core/IpcRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.Serialization;
 
 namespace JKang.IpcServiceFramework
@@ -17,6 +18,51 @@ namespace JKang.IpcServiceFramework
         public IEnumerable<Type> ParameterTypes { get; set; }
 
         [DataMember]
+        public IEnumerable<IpcRequestParameterType> ParameterTypesByName { get; set; }
+
+        [DataMember]
         public IEnumerable<Type> GenericArguments { get; set; }
+
+        [DataMember]
+        public IEnumerable<IpcRequestParameterType> GenericArgumentsByName { get; set; }
+    }
+
+    /// <summary>
+    /// Used to pass ParameterTypes annd GenericArguments by "Name" instead of by an explicit Type object.
+    /// This allows for ParameterTypes to resolve properly even if the assembly version isn't an exact match on the Client & Host.
+    /// </summary>
+    [DataContract]
+    public class IpcRequestParameterType
+    {
+        [DataMember]
+        public string ParameterType { get; private set; }
+
+        [DataMember]
+        public string AssemblyName { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IpcRequestParameterType"/> class.
+        /// </summary>
+        public IpcRequestParameterType()
+        {
+            ParameterType = null;
+            AssemblyName = null;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IpcRequestParameterType"/> class.
+        /// </summary>
+        /// <param name="paramType">The type of parameter.</param>
+        /// <exception cref="ArgumentNullException">paramType</exception>
+        public IpcRequestParameterType(Type paramType)
+        {
+            if (paramType == null)
+            {
+                throw new ArgumentNullException(nameof(paramType));
+            }
+
+            ParameterType = paramType.FullName;
+            AssemblyName = paramType.Assembly.GetName().Name;
+        }
     }
 }


### PR DESCRIPTION
Proposed implementation for #167 